### PR TITLE
Adding RKE as a docs item in the footer

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -20,6 +20,7 @@
               <li><a href="http://rancher.com/docs/rancher/v2.x/en/" target="blank">Rancher 2.0 Docs</a></li>
               <li><a href="https://rancher.com/docs/rancher/v1.6/en/" target="blank">Rancher 1.6 Docs</a></li>
               <li><a href="https://rancher.com/docs/os/v1.x/en/" target="blank">RancherOS</a></li>
+              <li><a href="https://rancher.com/docs/rke/v0.1.x/en/" target="blank">Rancher Kubernetes Engine (RKE)</a></li>
             </ul>
           </div>
 


### PR DESCRIPTION
I think it would be valuable to have the RKE docs linked from our main website. This is a minor fix, but our docs index shows 4 options (Rancher 1.x, Rancher 2.0, RancherOS, and RKE) whereas the original footer only showed (Rancher 1.x, Rancher 2.0, and Rancher OS)