### PR TITLE
show description before summary

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -48,11 +48,8 @@
             {{end}}
 
             <p>
-              {{ .Summary | safeHTML }}
-              {{ if .Truncated }}
-                <a href="{{ .RelPermalink }}">Read More…</a>
-              {{ end }}
-            </p>
+              {{ .Description | default .Summary | safeHTML }}
+          </p>
 
             <div class="row">
               {{ with .Params.author }}
@@ -90,10 +87,7 @@
               {{end}}
 
               <p class="m-t-0">
-                {{ .Summary | safeHTML }}
-                {{ if .Truncated }}
-                  <a href="{{ .RelPermalink }}">Read More…</a>
-                {{ end }}
+                {{ .Description | default .Summary | safeHTML }}
               </p>
 
               <div class="row middle-xs">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -75,7 +75,9 @@
 
           {{ else }}
 
+          {{ if eq .Section "events" }}
           <p class="text-muted">{{ .Description }}</p>
+          {{end}}
         {{end}}
 
 


### PR DESCRIPTION
this change shows the `description` field if present, and `.Summary` if not. it also makes cosmetic changes to the full article page, removing `description` for blog articles but leaving it for rodeo pages.