### PR TITLE
Layout/description

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -53,7 +53,7 @@
 
             <div class="detail"><span class="p-h-xs"></span>{{ $published }}</div>
 
-            {{ if ne $published $updated }}
+            {{ if and (ne $published $updated) (eq .Section "blog")}}
               <div class="detail pull-right"><span class="p-h-xs"></span>Updated: {{ $updated }}</div>
             {{end}}
           </div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -36,12 +36,6 @@
             {{end}}
           </div>
 
-          <div class="m-t-sm">
-            {{ with .Params.link }}
-                <a href="{{ . }}" class="btn bg-accent" target="_blank">Register Here</a>
-            {{end}}
-          </div>
-
           {{ else }}
 
           <div class="row middle-xs">
@@ -69,11 +63,6 @@
         {{ with .Params.title }}
           <h1 class="m-t-0">{{ . }}</h1>
         {{end}}
-
-        {{ with .Params.description }}
-          <p class="p-t-sm">{{ . }}</p>
-        {{end}}
-
 
         <!--list tags-->
         {{ if eq .Section "events" }}
@@ -106,7 +95,19 @@
             {{end}}
           {{end}}
 
-          {{ .Content }}
+          {{ with .Content }}
+          {{ . }}
+          {{ else }}
+          <p class="p-t-sm">{{ .Description }}</p>
+          {{ end }}
+
+          {{ if eq .Section "events" }}
+          <div class="m-t-sm">
+            {{ with .Params.link }}
+                <a href="{{ . }}" class="btn bg-accent" target="_blank">Register Here</a>
+            {{end}}
+          </div>
+          {{ end }}
 
           {{ if eq .Section "careers" }}
             <p><a class="btn bg-link" href="mailto:jobs@rancher.com?subject={{ .Title }}">Apply Now</a></p>


### PR DESCRIPTION
this PR extends the description edit we did for blogs to press and events articles. 

it also modifies the "updated" text that appears so that it does _not_ appear on anything other than blogs. it shouldn't appear on press releases or other non-blog content that we might edit after the fact.

last, it moves "Register Here" to below the article content.