### PR TITLE
Added ctaHeader code to 3 layouts.

### DIFF
--- a/layouts/_default/basic-1.html
+++ b/layouts/_default/basic-1.html
@@ -55,6 +55,18 @@
 
 {{ define "main" }}
 
+<!--cta Header-->
+{{ if and (.Params.ctaHeader) }}
+{{ with index .Site.Data.cta .Params.ctaHeader }}
+<div class="wrapper">
+<div class="cta-banner row center-xs middle-xs bg-info shadow rounded-corners">
+<h3 class="m-v-sm m-r-sm text-white">{{ .header }}</h3>
+<a href="{{ .link }}" target="_blank" class="btn border-btn">{{ .button }}</a>
+</div>
+</div>
+{{end}}
+{{end}}
+
 
   {{ .Content }}
 {{ end }}

--- a/layouts/_default/full-hero.html
+++ b/layouts/_default/full-hero.html
@@ -30,6 +30,18 @@
 
 {{ define "main" }}
 
+<!--cta Header-->
+{{ if and (.Params.ctaHeader) }}
+{{ with index .Site.Data.cta .Params.ctaHeader }}
+<div class="wrapper">
+<div class="cta-banner row center-xs middle-xs bg-info shadow rounded-corners">
+<h3 class="m-v-sm m-r-sm text-white">{{ .header }}</h3>
+<a href="{{ .link }}" target="_blank" class="btn border-btn">{{ .button }}</a>
+</div>
+</div>
+{{end}}
+{{end}}
+
   {{ .Content }}
 
 {{ end }}

--- a/layouts/_default/no-hero.html
+++ b/layouts/_default/no-hero.html
@@ -1,5 +1,17 @@
 {{ define "main" }}
 
+<!--cta Header-->
+{{ if and (.Params.ctaHeader) }}
+{{ with index .Site.Data.cta .Params.ctaHeader }}
+<div class="wrapper">
+<div class="cta-banner row center-xs middle-xs bg-info shadow rounded-corners">
+<h3 class="m-v-sm m-r-sm text-white">{{ .header }}</h3>
+<a href="{{ .link }}" target="_blank" class="btn border-btn">{{ .button }}</a>
+</div>
+</div>
+{{end}}
+{{end}}
+
   {{ .Content }}
 
 {{ end }}


### PR DESCRIPTION
Added ctaHeader code to 3 layouts:

basic-1
full-hero
no-hero

Tested on my local copy of the website and looks good (though there's no styling of course).

This PR is related to another PR to actually place the `ctaHeader` frontmatter in individual marketing pages to take advantage of this new banner code in their layout. 