### PR TITLE
Add left padding to docs side menu

### DIFF
--- a/assets/sass/pages/_docs.scss
+++ b/assets/sass/pages/_docs.scss
@@ -1002,7 +1002,7 @@
             padding-top: 16px;
             padding-bottom: 16px;
             padding-right: 40px;
-            padding-left: 0;
+            padding-left: 10px;
 
             color: #3d3d3d !important;
             font-family: 'Roboto';


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1999874/61188085-f0ca3180-a62e-11e9-9c67-948ad52718e9.png)
After:
![image](https://user-images.githubusercontent.com/1999874/61188086-f4f64f00-a62e-11e9-8480-6c128dc1103d.png)
