### PR TITLE
Edit documentation colors and font for legibility

### DIFF
--- a/assets/sass/components/_general.scss
+++ b/assets/sass/components/_general.scss
@@ -35,10 +35,10 @@ span {
   margin: 0;
   margin-bottom: 40px;
 
-  color: $c-green;
+  color: black;
   font-family: "Poppins";
   font-size: 11px;
-  font-weight: 700;
+  font-weight: 400;
   letter-spacing: 1.5px;
 
   text-transform: uppercase;

--- a/assets/sass/layout/_footer.scss
+++ b/assets/sass/layout/_footer.scss
@@ -16,9 +16,9 @@
 
     margin-bottom: 0;
 
-    color: $c-green;
+    color: black;
     font-size: 12px;
-    font-weight: 700;
+    font-weight: 400;
     letter-spacing: 0.5px;
 
     text-transform: uppercase;

--- a/assets/sass/pages/_docs.scss
+++ b/assets/sass/pages/_docs.scss
@@ -651,7 +651,6 @@
     }
 }
 
-
 .docs-container .side-menus {
     padding-right: 70px;
     padding-left: 0;
@@ -1000,7 +999,7 @@
         }
         > li > a {
             padding-top: 16px;
-            padding-bottom: 16px;
+            padding-bottom: 10px;
             padding-right: 40px;
             padding-left: 10px;
 
@@ -1151,6 +1150,7 @@
     .docs-wrap {}
 
     .texts-container {
+
         h1, h5 {
             margin-top: 5px;
             padding-bottom: 0;
@@ -1184,13 +1184,19 @@
 
         p {
             margin-bottom: 20px;
+            font-weight: normal;
 
             color: #3d3d3d;
-            font-size: 15px;
+            font-size: 16px;
             line-height: 1.665;
 
             &:last-child {
                 margin-bottom: 0;
+            }
+
+            code {
+                color: black;
+                font-weight: normal;
             }
         }
 
@@ -1216,7 +1222,17 @@
         }
 
         ol, ul {
+            font-weight: normal;
+            
             margin-bottom: 30px;
+
+            code {
+                line-height: 1.45;
+                font-weight: 300;
+                border: none;
+                color: black;
+                font-size: 16px;
+            }
 
             &:last-child {
                 margin-bottom: 0;
@@ -1225,9 +1241,8 @@
             li {
                 margin-bottom: 5px;
 
-                font-size: 15px;
-                font-weight: 300;
-                line-height: 1.4;
+                font-size: 16px;
+                line-height: 1.6;
 
                 &:last-child {
                     margin-bottom: 0;
@@ -1271,7 +1286,7 @@
             position: relative;
 
             width: 100%;
-
+            font-size: 16px;
             margin-bottom: 15px;
             padding-top: 5px;
 
@@ -1305,11 +1320,20 @@
                 padding: 6px 20px;
 
                 color: $c-gray;
-                font-size: 15px;
-                font-weight: 300;
+                font-size: 16px;
+                font-weight: normal;
                 line-height: 1.665;
 
                 border: 1px solid $c-gray-mid-light;
+
+                
+                code {
+                    line-height: 1.45;
+                    font-weight: 300;
+                    border: none;
+                    color: black;
+                    font-size: 16px;
+                }
             }
             tbody tr:nth-child(2n - 1) td {
                 background-color: #f2f5f5;
@@ -1359,9 +1383,10 @@
         blockquote {
             margin-top: 20px;
             margin-bottom: 20px;
-            padding: 35px;
-
-            background-color: rgba($c-blue, .1);
+            padding: 20px;
+            border: 1px solid $c-blue;
+            border-radius: 5px;
+            background-color: #effaff;
 
             p {
                 strong {
@@ -1378,15 +1403,15 @@
         pre {
             position: relative;
             overflow: auto;
-
+            background-color: #F6F8FA;
             padding: 30px;
 
-            background-color: #3d3d3d;
-
             code {
-                line-height: 1.3;
+                line-height: 1;
+                font-weight: 300;
                 border: none;
-                color: $c-green;
+                color: black;
+                font-size: 16px;
             }
         }
 
@@ -1473,7 +1498,7 @@
                     margin: 0;
                     margin-right: 5px;
 
-                    background-color: rgba($c-blue, .05);
+                    background-color: white;
 
                     a {
                         position: relative;
@@ -1490,7 +1515,13 @@
                     }
 
                     &.active {
-                        background-color: rgba(#fff, 1);
+                        background-color: white;
+                        border-left: 1px solid lightgray;
+                        border-right: 1px solid lightgray;
+                        border-top: 1px solid lightgray;
+                        border-bottom: 5px solid $c-blue;
+                        border-top-left-radius: 5px;
+                        border-top-right-radius: 5px;
 
                         a {
                             padding: 15px 20px;
@@ -1504,8 +1535,12 @@
 
             .tab-content {
                 position: relative;
-
-                background-color: #fff;
+                background-color: white;
+                border: 1px solid lightgray;
+                border-bottom-left-radius: 5px;
+                border-bottom-right-radius: 5px;
+                border-top-right-radius: 5px;
+                margin-bottom: 15px;
 
                 .tab-pane {
                     position: relative;
@@ -1523,7 +1558,7 @@
         .accordion {
             margin: 20px 0;
 
-            background-color: #f7f7f7;
+            background-color: white;
             border: 1px solid #efefef;
 
             input[name="accordion"] {
@@ -1800,10 +1835,13 @@
 
         pre {
             padding: 20px 15px;
+            background-color: #F6F8FA;
 
             code {
                 font-size: 10px;
                 line-height: 1.2;
+                color: black;
+                font-weight: normal;
             }
         }
 
@@ -1948,6 +1986,7 @@
     }
 
     .docs-container .texts-container {
+
         h1 {
             font-size: 35px;
             line-height: 1.4;
@@ -1984,10 +2023,13 @@
 
         pre {
             padding: 25px 20px;
+            background-color: #F6F8FA;
 
             code {
+                font-weight: normal;
                 font-size: 11px;
                 line-height: 1.2;
+                color: black;
             }
         }
 

--- a/assets/sass/variable/_color.scss
+++ b/assets/sass/variable/_color.scss
@@ -17,7 +17,7 @@ $c-emerald: #78c9cf;
 
 $c-gray: #3d3d3d;
 $c-gray-light: #ecf0f1;
-$c-gray-base-light: #f2f5f5;
+$c-gray-base-light: white;
 $c-gray-mid-light: #d0d4d7;
 
 $c-disabled-default: #777;

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -108,7 +108,7 @@
                                 col-6
                                 ">
                                 <div class="label">Resources</div>
-                                <li><a href="/docs/rancher/v2.x/en/">Rancher 2.x Docs</a></li>
+                                <li><a href="/docs/rancher/latest/en/">Rancher 2.x Docs</a></li>
                                 <li><a href="/docs/rancher/v1.6/en/">Rancher 1.6 Docs</a></li>
                                 <li><a href="/docs/rke/latest/en/">RKE Docs</a></li>
                                 <li><a href="/docs/k3s/latest/en/">k3s Docs</a></li>

--- a/theme.toml
+++ b/theme.toml
@@ -19,3 +19,6 @@ min_version = "0.26"
   name = ""
   homepage = ""
   repo = ""
+
+[params]
+    custom_css = ["css/docs.css"]


### PR DESCRIPTION
While looking at the website structure for an unrelated reason, I figured out how to change the documentation colors and tabs.

These changes would address this issue about the font weight https://github.com/rancherlabs/website/issues/1613 and this issue about the white background. https://github.com/rancherlabs/website/issues/1611

Below I've included screenshots of the before and after.

This can't be merged until it's reviewed by a bunch of people, so I've marked it as a draft.

**Installing Kubernetes - regular doc page**

Before:
<img width="1622" alt="Screen Shot 2020-07-01 at 7 35 23 AM" src="https://user-images.githubusercontent.com/20599230/86258423-ab6c8000-bb6f-11ea-8d57-a0efdaa4e5a1.png">

After:
<img width="1651" alt="Screen Shot 2020-07-01 at 11 22 24 AM" src="https://user-images.githubusercontent.com/20599230/86278398-2a23e600-bb8d-11ea-9fa3-fe24019f9265.png">

**Tables within a tab**
Before:
<img width="1645" alt="Screen Shot 2020-07-01 at 7 39 48 AM" src="https://user-images.githubusercontent.com/20599230/86258352-968fec80-bb6f-11ea-8362-0aaa552a0ef9.png">

After:
<img width="1641" alt="Screen Shot 2020-07-01 at 11 25 01 AM" src="https://user-images.githubusercontent.com/20599230/86278625-8be45000-bb8d-11ea-9da1-fc737adc2fdf.png">


**Bulleted lists with monospace font inside**
Before:
<img width="1640" alt="Screen Shot 2020-07-01 at 7 38 35 AM" src="https://user-images.githubusercontent.com/20599230/86258387-a27bae80-bb6f-11ea-9079-b75449fe9939.png">
After:
<img width="1655" alt="Screen Shot 2020-07-01 at 11 26 00 AM" src="https://user-images.githubusercontent.com/20599230/86278706-b0402c80-bb8d-11ea-8fd4-a9e63b12b6ec.png">

**Steps and code samples within a tab**

Before:
<img width="1641" alt="Screen Shot 2020-07-01 at 7 38 56 AM" src="https://user-images.githubusercontent.com/20599230/86258385-a1e31800-bb6f-11ea-8dea-6c4c96e3e386.png">

After:
<img width="1645" alt="Screen Shot 2020-07-01 at 11 26 56 AM" src="https://user-images.githubusercontent.com/20599230/86278798-ce0d9180-bb8d-11ea-853e-87799408b27a.png">


**Table within an accordion**
Before:
<img width="1655" alt="Screen Shot 2020-07-01 at 7 39 32 AM" src="https://user-images.githubusercontent.com/20599230/86258368-9abc0a00-bb6f-11ea-9717-c757ce4c4773.png">
After:
<img width="1663" alt="Screen Shot 2020-07-01 at 11 27 54 AM" src="https://user-images.githubusercontent.com/20599230/86278885-f0071400-bb8d-11ea-92f7-de40243cc213.png">



