### PR TITLE
Fix header sizes for docs pages

### DIFF
--- a/assets/sass/pages/_docs.scss
+++ b/assets/sass/pages/_docs.scss
@@ -1765,19 +1765,55 @@
 
     .docs-container .texts-container {
         h1 {
+            margin-bottom: 40px;
+            font-size: 40px;
+            font-weight: 300;
             font-size: 25px;
+            margin-bottom: 20px;
+            font-weight: 400;
+            margin-top: 0;
             line-height: 1.4;
         }
-
+      
         h2 {
-            font-size: 23px;
             line-height: 1.4;
+            font-size: 32px;
+            font-weight: 300;
+            margin-bottom: 20px;
+            margin-top: 0;
         }
-
-        h3, h4 {
+      
+        h3 {
+            font-size: 25px;
+            font-size: 28px;
+            font-weight: 300;
+            margin-bottom: 20px;
+            margin-top: 0;
+        }
+      
+        h4 {
+            font-size: 20px;
+            font-size: 24px;
+            font-weight: 300;
             margin-bottom: 10px;
-
-            font-size: 22px;
+            margin-top: 0;
+        }
+      
+        h5 {
+            margin-bottom: 1em;
+            font-size: 20px;
+            font-size: 18px;
+            font-weight: 300;
+            font-weight: bold;
+            margin-bottom: 10px;
+            margin-top: 0;
+        }
+      
+        h6 {
+            font-size: 16px;
+            font-weight: 300;
+            margin-bottom: 10px;
+            margin-top: 0;
         }
 
         hr {


### PR DESCRIPTION
To make this PR I copied the heading styles from diabloshogunate’s PR https://github.com/rancherlabs/website-theme/pull/170/files. The CSS was right, but the changes needed to be made to _docs.scss to affect the docs. https://github.com/rancherlabs/website/issues/1380

Before:

<img width="981" alt="Screen Shot 2021-09-02 at 11 44 40 AM" src="https://user-images.githubusercontent.com/20599230/131902147-e178c33b-44e1-4194-97af-68749367f635.png">

After:

<img width="1246" alt="Screen Shot 2021-09-02 at 11 55 26 AM" src="https://user-images.githubusercontent.com/20599230/131902125-766c5d9f-1ccc-4654-ac08-17de29b07c1b.png">
