### PR TITLE
Fix docs header styles for more pages

### DIFF
--- a/assets/sass/pages/_docs.scss
+++ b/assets/sass/pages/_docs.scss
@@ -1151,25 +1151,49 @@
     .docs-wrap {}
 
     .texts-container {
-        h1, h5 {
-            margin-top: 5px;
-            padding-bottom: 0;
-
-            color: $c-blue-dark1;
-            font-family: 'Poppins';
+        h1 {
             font-size: 40px;
-            font-weight: 200;
+            margin-bottom: 20px;
+            font-weight: 400;
+            margin-top: 0;
+            line-height: 1.4;
+        }
+      
+        h2 {
+            line-height: 1.4;
+            font-size: 32px;
+            font-weight: 400;
+            margin-bottom: 20px;
+            margin-top: 0;
         }
 
-        h3,
-        h4 {
-            margin-bottom: 15px;
-            padding-top: 5px;
+        h3 {
+            font-size: 28px;
+            font-weight: 400;
+            margin-bottom: 20px;
+            margin-top: 0;
+        }
 
-            color: $c-blue-dark1;
-            font-family: 'Poppins';
-            font-size: 25px;
+        h4 {
+            font-size: 24px;
+            font-weight: 400;
+            margin-bottom: 10px;
+            margin-top: 0;
+        }
+
+        h5 {
+            margin-bottom: 1em;
+            font-size: 18px;
+            font-weight: 600;
+            margin-bottom: 10px;
+            margin-top: 0;
+        }
+
+        h6 {
+            font-size: 16px;
             font-weight: 300;
+            margin-bottom: 10px;
+            margin-top: 0;
         }
 
         h1, h2, h3, h4, h5 {


### PR DESCRIPTION
@jtravee 
Before:
<img width="1021" alt="Screen Shot 2021-09-28 at 8 30 37 PM" src="https://user-images.githubusercontent.com/20599230/135199169-11f39dc9-7726-47df-9a13-7901f0fb1f44.png">

After:
<img width="1044" alt="Screen Shot 2021-09-28 at 8 33 27 PM" src="https://user-images.githubusercontent.com/20599230/135199193-04cf4b8f-f8c1-4b27-84a7-5563c6c73d19.png">
