### PR TITLE
Make fonts more legible in docs

### DIFF
--- a/assets/sass/components/_general.scss
+++ b/assets/sass/components/_general.scss
@@ -78,8 +78,8 @@ span {
 p {
   margin-top: 0;
 
-  font-size: 18px;
-  font-weight: 300;
+  font-size: 20px;
+  font-weight: 400;
 
   line-height: 1.775;
 
@@ -737,7 +737,7 @@ button[disabled="disabled"] {
 
     color: #fff;
     font-family: "Poppins";
-    font-weight: 300;
+    font-weight: 400;
     font-size: 25px;
     line-height: 50px;
     text-align: center;
@@ -890,7 +890,7 @@ button[disabled="disabled"] {
 
   .texts-container {
     .title-label {
-      font-weight: 300;
+      font-weight: 400;
 
       &:last-child {
         margin-bottom: 0;

--- a/assets/sass/pages/_docs.scss
+++ b/assets/sass/pages/_docs.scss
@@ -408,7 +408,7 @@
                 }
 
                 .description-label {
-                    font-size: 18px;
+                    font-size: 16px;
 
                     @include textElipsis(3, 1.5);
                 }
@@ -456,7 +456,7 @@
                 }
 
                 .description-label {
-                    font-size: 18px;
+                    font-size: 16px;
 
                     @include textElipsis(3, 1.5);
                 }
@@ -487,7 +487,7 @@
                 }
 
                 .description-label {
-                    font-size: 18px;
+                    font-size: 16px;
 
                     @include textElipsis(3, 1.5);
                 }
@@ -518,7 +518,7 @@
                 }
 
                 .description-label {
-                    font-size: 18px;
+                    font-size: 16px;
 
                     @include textElipsis(3, 1.5);
                 }
@@ -812,7 +812,7 @@
 
         color: #313131;
         font-family: 'Roboto';
-        font-size: 15px;
+        font-size: 16px;
         font-weight: bold;
         letter-spacing: 1px;
         line-height: 50px;
@@ -917,7 +917,7 @@
 
             color: $c-blue !important;
             font-family: 'Roboto';
-            font-size: 15px;
+            font-size: 16px;
             font-weight: 400;
             text-transform: initial;
             letter-spacing: 0;
@@ -1006,7 +1006,7 @@
 
             color: #3d3d3d !important;
             font-family: 'Roboto';
-            font-size: 15px;
+            font-size: 16px;
             font-weight: 500;
             text-transform: initial;
             letter-spacing: 0;
@@ -1183,7 +1183,7 @@
 
         h5 {
             margin-bottom: 1em;
-            font-size: 18px;
+            font-size: 16px;
             font-weight: 600;
             margin-bottom: 10px;
             margin-top: 0;
@@ -1191,7 +1191,7 @@
 
         h6 {
             font-size: 16px;
-            font-weight: 300;
+            font-weight: 400;
             margin-bottom: 10px;
             margin-top: 0;
         }
@@ -1210,7 +1210,7 @@
             margin-bottom: 20px;
 
             color: #3d3d3d;
-            font-size: 15px;
+            font-size: 16px;
             line-height: 1.665;
 
             &:last-child {
@@ -1249,8 +1249,8 @@
             li {
                 margin-bottom: 5px;
 
-                font-size: 15px;
-                font-weight: 300;
+                font-size: 16px;
+                font-weight: 400;
                 line-height: 1.4;
 
                 &:last-child {
@@ -1312,8 +1312,8 @@
                 margin-top: 20px;
                 margin-bottom: 15px;
 
-                font-size: 15px;
-                font-weight: bold;
+                font-size: 16px;
+                font-weight: 500;
                 text-align: left;
             }
 
@@ -1329,8 +1329,8 @@
                 padding: 6px 20px;
 
                 color: $c-gray;
-                font-size: 15px;
-                font-weight: 300;
+                font-size: 16px;
+                font-weight: 400;
                 line-height: 1.665;
 
                 border: 1px solid $c-gray-mid-light;
@@ -1357,7 +1357,7 @@
                 width: 20%;
 
                 color: #313131;
-                font-size: 15px;
+                font-size: 16px;
                 font-family: 'Roboto';
                 font-weight: 500;
                 letter-spacing: 0;
@@ -1791,7 +1791,6 @@
         h1 {
             margin-bottom: 40px;
             font-size: 40px;
-            font-weight: 300;
             font-size: 25px;
             margin-bottom: 20px;
             font-weight: 400;
@@ -1802,7 +1801,7 @@
         h2 {
             line-height: 1.4;
             font-size: 32px;
-            font-weight: 300;
+            font-weight: 400;
             margin-bottom: 20px;
             margin-top: 0;
         }
@@ -1810,7 +1809,7 @@
         h3 {
             font-size: 25px;
             font-size: 28px;
-            font-weight: 300;
+            font-weight: 400;
             margin-bottom: 20px;
             margin-top: 0;
         }
@@ -1818,7 +1817,7 @@
         h4 {
             font-size: 20px;
             font-size: 24px;
-            font-weight: 300;
+            font-weight: 400;
             margin-bottom: 10px;
             margin-top: 0;
         }
@@ -1826,16 +1825,15 @@
         h5 {
             margin-bottom: 1em;
             font-size: 20px;
-            font-size: 18px;
-            font-weight: 300;
-            font-weight: bold;
+            font-size: 16px;
+            font-weight: 400;
             margin-bottom: 10px;
             margin-top: 0;
         }
       
         h6 {
             font-size: 16px;
-            font-weight: 300;
+            font-weight: 400;
             margin-bottom: 10px;
             margin-top: 0;
         }
@@ -1885,7 +1883,7 @@
         }
 
         h3, h4 {
-            font-size: 18px;
+            font-size: 16px;
         }
     }
 }
@@ -2029,7 +2027,7 @@
         }
 
         p {
-            font-size: 15px;
+            font-size: 16px;
         }
 
         ol, ul {
@@ -2038,7 +2036,7 @@
             li {
                 margin-bottom: 12px;
 
-                font-size: 15px;
+                font-size: 16px;
             }
         }
 


### PR DESCRIPTION
- Removes font weights less than 400
- Avoids using font sizes smaller than 16px for normal text


Before:

<img width="1283" alt="Screen Shot 2021-11-20 at 4 14 23 PM" src="https://user-images.githubusercontent.com/20599230/142743543-377bfee9-026a-4022-91ba-2b5a231b5822.png">

After
<img width="1277" alt="Screen Shot 2021-11-20 at 4 19 22 PM" src="https://user-images.githubusercontent.com/20599230/142743622-c0d72b28-6de0-4387-8bff-ef25f09106e8.png">
:
