### PR TITLE
Make tabs consistent

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -26,400 +26,412 @@
     <header>
         <nav>
             <div class="mobile-header-container">
-                <div class="mobile-nav-header">
-                    <div class="logo">
-                        <a href="/"><img class="logo-image" src="https://rancher.com/assets/img/logos/rancher-logo-horiz-color.svg" alt="The Logo of Rancher: an Open Source Kubernetes Multi Cluster Management Platform"></a>
-                    </div>
-
-                    <div class="mobile-search"><a href="#" class="search-open" data-launch-id="open-search"><img class="icon" src="/imgs/icon-search-mobile.svg" alt="Gray Search Icon"></a></div>
-
-                    <div class="mobile-menu-opener">
-                        <span></span>
-                        <span></span>
-                        <span></span>
-                    </div>
+              <div class="mobile-nav-header">
+                <div class="logo">
+                  <a href="https://rancher.com">
+                    <img class="logo-image" src="https://rancher.com/assets/img/logos/rancher-logo-horiz-color.svg" alt="The Logo of Rancher: an Open Source Kubernetes Multi Cluster Management Platform">
+                  </a>
                 </div>
-
-                <div class="nav-mobile-menus jquery-accordion-menu">
-                    <ul class="mobile-menus-wrap">
-                        <li class="mobile-menu-item">
-                            <a class="mobile-menu" href="#">Why Rancher?</a>
-
-                            <ul class="submenu submenus-wrap">
-                                <li class=""><a href="/why-rancher/">Why Rancher?</a></li>
-                                <li class=""><a href="/kubernetes/">Why Kubernetes?</a></li>
-                                <li class=""><a href="/why-rancher/rancher-strengthens-kubernetes/">How Rancher Strengthens Kubernetes</a></li>
-                                <li class=""><a href="/why-rancher/rancher-difference/">The Rancher Difference</a></li>
-                            </ul>
-                        </li>
-                        <li class="mobile-menu-item">
-                            <a class="mobile-menu" href="#">Products</a>
-
-                            <ul class="submenu submenus-wrap">
-                                <li><a href="/products/">Overview</a></li>
-                                <li><a href="/products/rancher/">Rancher</a></li>
-                                <li><a href="/products/hosted-rancher/">Hosted Rancher</a></li>
-                                <li><a href="/products/k3s/">k3s</a></li>
-                                <li><a href="/products/longhorn/" target="">Longhorn</a></li>
-                                <li><a href="/request-a-demo/">Request a demo</a></li>
-                            </ul>
-                        </li>
-                        <li class="mobile-menu-item">
-                            <a class="mobile-menu" href="#">Customers</a>
-
-                            <ul class="submenu submenus-wrap">
-                                <li><a href="/customers/continental/">Continental</a></li>
-                                <li><a href="/customers/ubisoft/">Ubisoft</a></li>
-                                <li><a href="/customers/schneider-electric/">Schneider Electric</a></li>
-                                <li><a href="/customers/mpac/">MPAC</a></li>
-                                <li><a href="/customers/">See All Customer Stories</a></li>
-                            </ul>
-                        </li>
-                        <li class="mobile-menu-item">
-                            <a class="mobile-menu" href="#">Community</a>
-
-                            <ul class="submenu submenus-wrap">
-                                <li><a href="/community">Overview</a></li>
-                                <li><a href="/learning-paths">Learning Paths</a></li>
-                                <li><a href="/training/">Training</a></li>
-                                <li><a href="/tutorials/">Tutorials</a></li>
-                                <li><a href="/events/">Events</a></li>
-                                <li><a href="/online-meetups/">Online Meetups</a></li>
-                                <li><a href="/rodeos/">Rancher Rodeos</a></li>
-                                <li><a href="/kubernetes-master-class/">Kubernetes Master Classes</a></li>
-                                <li><a href="https://academy.rancher.com/">Get Certified!</a></li>
-                                <!-- <li><a href="/writing-program/">Rancher Writing Program</a></li> -->
-                                <li><a href="/quick-start/">Getting Started Guide</a></li>
-                                <li><a href="https://forums.rancher.com/">Forums</a></li>
-                                <li><a href="http://slack.rancher.io/">Slack</a></li>
-                                <li><a href="https://github.com/rancher">Github</a></li>
-                            </ul>
-                        </li>
-                        <li class="mobile-menu-item">
-                        <a class="mobile-menu" href="#">Resources</a>
-
-                            <ul class="submenu submenus-wrap">
-                                <li><a href="/docs">Docs</a></li>
-                                <li><a href="/resources/#analyst-reports">Analyst Reports</a></li>
-                                <li><a href="/resources/#whitepapers">White Papers</a></li>
-                                <li><a href="/resources/#ebooks">Ebooks</a></li>
-                                <li><a href="/resources/#videos">Videos</a></li>
-                                <li><a href="/resources/#podcasts">Podcasts</a></li>
-                                <li><a href="/blog/">Blog</a></li>
-                            </ul>
-                        </li>
-                        <li class="mobile-menu-item">
-                        <a class="mobile-menu" href="#">Projects</a>
-
-                            <ul class="submenu submenus-wrap">
-                                <li><a href="http://k3os.io/" target="_blank">k3OS</a></li>
-                                <li><a href="http://rio.io/" target="_blank">Rio</a></li>
-                                <li><a href="http://submariner.io/" target="_blank">Submariner</a></li>
-                                <li><a href="https://longhorn.io/" target="_blank">Longhorn</a></li>
-                            </ul>
-                        </li>
-                        <li class="mobile-menu-item">
-                            <a class="mobile-menu" href="#">Company</a>
-
-                            <ul class="submenu submenus-wrap">
-                                <li><a href="/about/">About us</a></li>
-                                <li><a href="/partners/">Partners</a></li>
-                                <li><a href="/press/">Press</a></li>
-                                <li><a href="/events/">Events</a></li>
-                                <li><a href="/careers/">Careers</a></li>
-                                <li><a href="/blog/">Blog</a></li>
-                            </ul>
-                        </li>
-
-                        <li class="mobile-menu-item option-menu"><a href="/docs/">Docs</a></li>
-                        <!-- <li class="mobile-menu-item option-menu"><a href="/support">Support</a></li> -->
-                        <li class="mobile-menu-item option-menu"><a href="/request-a-demo/">Request a demo</a></li>
-                        <li class="mobile-menu-item option-menu"><a href="/contact/">Contact</a></li>
-                        <li class="mobile-menu-item option-menu"><a href="/pricing/">Pricing</a></li>
-                        <li class="mobile-menu-item option-menu get-started"><a href="/quick-start/">Get started</a></li>
+                <div class="mobile-search">
+                  <!-- <a href="#" class="search-open" data-launch-id="open-search">
+                    <img
+                      class="icon"
+                      src="https://rancher.com/assets/img/icons/icon-search-mobile.svg"
+                      alt="Gray Search Icon"
+                    />
+                  </a> -->
+                </div>
+                <div class="mobile-menu-opener">
+                  <span></span>
+                  <span></span>
+                  <span></span>
+                </div>
+              </div>
+              <div class="nav-mobile-menus jquery-accordion-menu">
+                <ul class="mobile-menus-wrap">
+                  <li class="mobile-menu-item">
+                    <a class="mobile-menu" href="javascript:void(0)">Why Rancher?<span class="submenu-indicator"><span class="object1"></span><span class="object2"></span><span class="object3"></span></span></a>
+                    <ul class="submenu submenus-wrap">
+                      <li class=""><a href="https://rancher.com/why-rancher" rel="noopener">Why Rancher?</a></li>
+                      <li class=""><a href="https://rancher.com/kubernetes" rel="noopener">Why Kubernetes?</a></li>
+                      <li class="">
+                        <a href="https://rancher.com/why-rancher/rancher-strengthens-kubernetes" rel="noopener">How We strengthen Kubernetes​</a>
+                      </li>
+                      <li class="">
+                        <a href="https://rancher.com/why-rancher/rancher-difference" rel="noopener">Our Difference​</a>
+                      </li>
                     </ul>
-                </div>
+                  </li>
+                  <li class="mobile-menu-item">
+                    <a class="mobile-menu" href="javascript:void(0)">Products<span class="submenu-indicator"><span class="object1"></span><span class="object2"></span><span class="object3"></span></span></a>
+                    <ul class="submenu submenus-wrap">
+                      <li><a href="https://rancher.com/products" rel="noopener">All Products</a></li>
+                      <li><a href="https://rancher.com/products/rancher" rel="noopener">Rancher</a></li>
+                      <li><a href="https://www.suse.com/products/suse-rancher-hosted/" rel="noopener">Hosted Rancher</a></li>
+                      <li><a href="https://rancher.com/products/harvester" rel="noopener">Harvester</a></li>
+                      <li><a href="https://rancher.com/products/rke" rel="noopener">RKE</a></li>
+                      <li><a href="https://rancher.com/products/longhorn" rel="noopener">Longhorn</a></li>
+                      <li><a href="https://rancher.com/products/k3s" rel="noopener">K3s</a></li>
+                    </ul>
+                  </li>
+                  <li class="mobile-menu-item">
+                    <a class="mobile-menu" href="https://rancher.com/docs/" rel="noopener">
+                        Docs
+                    </a>
+                  </li>
+                  <li class="mobile-menu-item">
+                    <a class="mobile-menu" href="javascript:void(0)">Learn<span class="submenu-indicator"><span class="object1"></span><span class="object2"></span><span class="object3"></span></span></a>
+  
+                    <ul class="submenu submenus-wrap">
+                      <li><a href="https://rancher.com/learn-the-basics">Learn the Basics</a></li>
+                      <li><a href="https://rancher.com/grow-your-skills">Grow Your Skills</a></li>
+                      <li><a href="https://training.suse.com/certification/sca-rancher-2-5/">Get Certified</a></li>
+                      <li><a href="https://rancher.com/docs/">Access Documentation</a></li>
+                      <li><a href="https://www.suse.com/c/rancherblog/">Read the Blogs</a></li>
+                      <li><a href="https://rancher.com/content-library">Content Library</a></li>
+                    </ul>
+                  </li>
+                  <li class="mobile-menu-item">
+                    <a class="mobile-menu" href="https://rancher.com/community" rel="noopener">Community<span class="submenu-indicator"><span class="object1"></span><span class="object2"></span><span class="object3"></span></span></a>
+                    <ul class="submenu submenus-wrap">
+                      <li><a href="https://rancher.com/about">About Us</a></li>
+                      <li><a href="/community">Join the Community</a></li>
+                      <li><a href="https://forums.rancher.com/">Forums</a></li>
+                      <li><a href="https://slack.rancher.io/">Slack</a></li>
+                      <li><a href="https://rancher.com/events">Events &amp; Webinars</a></li>
+                    </ul>
+                  </li>
+  
+                  <li class="mobile-menu-item option-menu">
+                    <a href="https://rancher.com/government" onclick="if (confirm('You\'re leaving Rancher and opening RGS?')){return true;}else{event.stopPropagation(); event.preventDefault();};" rel="noopener">Government</a>
+                  </li>
+                  <li class="mobile-menu-item option-menu">
+                    <a href="https://www.suse.com/" rel="noopener">SUSE.COM</a>
+                  </li>
+                  <li class="mobile-menu-item option-menu">
+                    <a href="https://rancher.com/pricing" rel="noopener">Pricing</a>
+                  </li>
+                  <li class="mobile-menu-item option-menu get-started">
+                    <a href="https://rancher.com/quick-start" rel="noopener">Get started</a>
+                  </li>
+                </ul>
+              </div>
             </div>
-
+  
             <div class="header-container">
-                <div class="header-wrap">
-                    <div class="header-option-menus">
-                        <ul>
-                            <li><a href="/docs/">Docs</a></li>
-                            <li><a href="/request-a-demo/">Request a demo</a></li>
-                            <li><a href="/pricing/">Pricing</a></li>
-                            <!-- <li><a href="/support">Support</a></li> -->
-                            <li><a href="/contact/">Contact</a></li>
-                            <li class="search"><a href="#" class="search-open" data-launch-id="open-search"><img class="icon" src="/imgs/icon-search.svg"></a></li>
-                        </ul>
-                    </div>
-
-                    <div class="header-primary-menus">
-                        <div class="logo">
-                            <a href="/"><img class="logo-image" src="https://rancher.com/assets/img/logos/rancher-logo-horiz-color.svg" alt="Rancher Logo"></a>
-                        </div>
-
-                        <!--    PRIMARY MENUS HERE --> 
-                        <div class="primary-menus">
-                            <ul class="primary-menus-wrap">
-                                <li class="primary-menu-item menu-why_rancher ">
-                                    <a class="primary-menu" href="https://rancher.com/why-rancher" rel="noopener">Why RANCHER?</a>
-                        
-                                    <ul class="primary-menus-sub">
-                                        <div class="grid-container">
-                                            <div class="row">
-                                                <div class="col">
-                                                    <li class="menus-container">
-                                                        <a href="https://rancher.com/why-rancher" rel="noopener" class="">
-                                                            <span>Why Rancher?</span>
-                                                            <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                    <path d="m19.5 12 5 5-5 5"></path>
-                                                                    <path d="m24.5 17h-15"></path>
-                                                                </g>
-                                                            </svg>
-                                                        </a>
-                                                        <a href="https://rancher.com/kubernetes" rel="noopener" class="">
-                                                            <span>Why Kubernetes?</span>
-                                                            <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                    <path d="m19.5 12 5 5-5 5"></path>
-                                                                    <path d="m24.5 17h-15"></path>
-                                                                </g>
-                                                            </svg>
-                                                        </a>
-                                                        <a href="https://rancher.com/why-rancher/rancher-strengthens-kubernetes" class="">
-                                                            <span>How We strengthen Kubernetes&ZeroWidthSpace;</span>
-                                                            <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                    <path d="m19.5 12 5 5-5 5"></path>
-                                                                    <path d="m24.5 17h-15"></path>
-                                                                </g>
-                                                            </svg>
-                                                        </a>
-                                                        <a href="https://rancher.com/why-rancher/rancher-difference" class="">
-                                                            <span>Our Difference&ZeroWidthSpace; </span>
-                                                            <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                    <path d="m19.5 12 5 5-5 5"></path>
-                                                                    <path d="m24.5 17h-15"></path>
-                                                                </g>
-                                                            </svg>
-                                                        </a>
-                                                    </li>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </ul>
-                                </li>
-                                <li class="primary-menu-item menu-products ">
-                                    <a class="primary-menu" href="https://rancher.com/products" rel="noopener">Software</a>
-                                    <ul class="primary-menus-sub">
-                                        <div class="grid-container">
-                                            <div class="row">
-                                                <div class="col-12 right">
-                                                    <ul>
-                                                        <li class="menus-container">
-                                                            <a href="https://rancher.com/products" class="menu-sub-block-item ">
-                                                                <span>All Products</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://rancher.com/products/rancher" class="menu-sub-block-item ">
-                                                                <span>Rancher</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://www.suse.com/products/suse-rancher-hosted/" target="_blank" class="menu-sub-block-item">
-                                                                <span>Hosted Rancher</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://rancher.com/products/rke" class="menu-sub-block-item ">
-                                                                <span>RKE</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://rancher.com/products/longhorn" class="menu-sub-block-item ">
-                                                                <span>Longhorn</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://rancher.com/products/k3s" class="menu-sub-block-item ">
-                                                                <span>K3s</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                        </li>
-                                                    </ul>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </ul>
-                                </li>
-                                <li class="primary-menu-item menu-products ">
-                                    <a class="primary-menu" href="https://rancher.com/learn-the-basics">Learn</a>
-                                    <ul class="primary-menus-sub">
-                                        <div class="grid-container">
-                                            <div class="row">
-                                                <div class="col-12 right">
-                                                    <ul>
-                                                        <li class="menus-container">
-                                                            <a href="https://rancher.com/learn-the-basics" class="menu-sub-block-item ">
-                                                                <span>Learn the Basics</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://rancher.com/grow-your-skills" class="menu-sub-block-item ">
-                                                                <span>Grow Your Skills</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://training.suse.com/certification/sca-rancher-2-5/" class="menu-sub-block-item">
-                                                                <span>Get Certified</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://rancher.com/docs/" class="menu-sub-block-item">
-                                                                <span>Access Documentation</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://www.suse.com/c/rancherblog/" class="menu-sub-block-item">
-                                                                <span>Read the Blogs</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://rancher.com/content-library" class="menu-sub-block-item ">
-                                                                <span>Content Library</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                        </li>
-                                                    </ul>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </ul>
-                        
-                                </li>
-                                <li class="primary-menu-item menu-company ">
-                                    <a class="primary-menu" href="https://rancher.com/Community" rel="noopener">Community</a>
-                                    <ul class="primary-menus-sub">
-                                        <div class="grid-container">
-                                            <div class="row">
-                                                <div class="col-12 right">
-                                                    <ul>
-                                                        <li class="menus-container">
-                                                            <a href="https://rancher.com/about" class="menu-sub-block-item ">
-                                                                <span>About Us</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://www.suse.com/community" class="menu-sub-block-item">
-                                                                <span>Join the Community</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://forums.rancher.com/" class="menu-sub-block-item">
-                                                                <span>Forums</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://slack.rancher.io/" class="menu-sub-block-item">
-                                                                <span>Slack</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                            <a href="https://rancher.com/events" class="menu-sub-block-item ">
-                                                                <span>Events &amp; Webinars</span>
-                                                                <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
-                                                                    <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
-                                                                        <path d="m19.5 12 5 5-5 5"></path>
-                                                                        <path d="m24.5 17h-15"></path>
-                                                                    </g>
-                                                                </svg>
-                                                            </a>
-                                                        </li>
-                                                    </ul>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </ul>
-                                </li>
-                                <li class="primary-menu-item menu-get_started get-started">
-                                    <a href="https://rancher.com/quick-start">Get started</a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
+              <div class="header-wrap">
+                <div class="header-option-menus">
+                  <ul>
+                    <li><a href="https://rancher.com/government" onclick="if (confirm('You\'re leaving Rancher and opening RGS?')){return true;}else{event.stopPropagation(); event.preventDefault();};" rel="noopener">Government</a></li>
+                    <li><a href="https://www.suse.com/">SUSE.COM</a></li>
+                    <li><a href="https://rancher.com/pricing" class="">Pricing</a></li>
+                    <!-- <li class="search">
+                      <a href="#" class="search-open" data-launch-id="open-search" rel="noopener">
+                        <img class="icon" src="https://rancher.com/assets/img/icons/icon-search.svg" alt="Gray Search Icon"/>
+                      </a>
+                    </li> -->
+                  </ul>
                 </div>
+  
+                <div class="header-primary-menus">
+                  <div class="logo">
+                    <a href="https://rancher.com">
+                      <img class="logo-image" src="https://rancher.com/assets/img/logos/rancher-logo-horiz-color.svg" alt="Rancher Logo">
+                    </a>
+                  </div>
+  
+                  <div class="primary-menus">
+                    <ul class="primary-menus-wrap">
+                      <li class="primary-menu-item menu-why_rancher active">
+                        <a class="primary-menu" href="https://rancher.com/why-rancher" rel="noopener">Why RANCHER?</a>
+  
+                        <ul class="primary-menus-sub">
+                          <div class="grid-container">
+                            <div class="row">
+                              <div class="col">
+                                <li class="menus-container">
+                                  <a href="https://rancher.com/why-rancher" rel="noopener" class="link_active">
+                                    <span>Why Rancher?</span>
+                                    <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                      <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                        <path d="m19.5 12 5 5-5 5"></path>
+                                        <path d="m24.5 17h-15"></path>
+                                      </g>
+                                    </svg>
+                                  </a>
+                                  <a href="https://rancher.com/kubernetes" rel="noopener" class="">
+                                    <span>Why Kubernetes?</span>
+                                    <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                      <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                        <path d="m19.5 12 5 5-5 5"></path>
+                                        <path d="m24.5 17h-15"></path>
+                                      </g>
+                                    </svg>
+                                  </a>
+                                  <a href="https://rancher.com/why-rancher/rancher-strengthens-kubernetes" class="">
+                                    <span>How We strengthen Kubernetes​</span>
+                                    <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                      <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                        <path d="m19.5 12 5 5-5 5"></path>
+                                        <path d="m24.5 17h-15"></path>
+                                      </g>
+                                    </svg>
+                                  </a>
+                                  <a href="https://rancher.com/why-rancher/rancher-difference" class="">
+                                    <span>Our Difference​ </span>
+                                    <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                      <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                        <path d="m19.5 12 5 5-5 5"></path>
+                                        <path d="m24.5 17h-15"></path>
+                                      </g>
+                                    </svg>
+                                  </a>
+                                </li>
+                              </div>
+                            </div>
+                          </div>
+                        </ul>
+                      </li>
+                      <li class="primary-menu-item menu-products ">
+                        <a class="primary-menu" href="https://rancher.com/products" rel="noopener">Products</a>
+                        <ul class="primary-menus-sub">
+                          <div class="grid-container">
+                            <div class="row">
+                              <div class="col-12 right">
+                                <ul>
+                                  <li class="menus-container">
+                                    <a href="https://rancher.com/products" class="menu-sub-block-item ">
+                                      <span>All Products</span>
+                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                        <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                          <path d="m19.5 12 5 5-5 5"></path>
+                                          <path d="m24.5 17h-15"></path>
+                                        </g>
+                                      </svg>
+                                    </a>
+                                    <a href="https://rancher.com/products/rancher" class="menu-sub-block-item ">
+                                      <span>Rancher</span>
+                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                        <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                          <path d="m19.5 12 5 5-5 5"></path>
+                                          <path d="m24.5 17h-15"></path>
+                                        </g>
+                                      </svg>
+                                    </a>
+                                    <a href="https://www.suse.com/products/suse-rancher-hosted/" target="_blank" class="menu-sub-block-item">
+                                      <span>Hosted Rancher</span>
+                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                        <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                          <path d="m19.5 12 5 5-5 5"></path>
+                                          <path d="m24.5 17h-15"></path>
+                                        </g>
+                                      </svg>
+                                    </a>
+                                    <a href="https://rancher.com/products/harvester" class="menu-sub-block-item ">
+                                      <span>Harvester</span>
+                                        <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                          <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                            <path d="m19.5 12 5 5-5 5"></path>
+                                            <path d="m24.5 17h-15"></path>
+                                          </g>
+                                         </svg>
+                                    </a>
+                                    <a href="https://rancher.com/products/rancher-desktop" class="menu-sub-block-item ">
+                                      <span>Rancher Desktop</span>
+                                        <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                          <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                            <path d="m19.5 12 5 5-5 5"></path>
+                                            <path d="m24.5 17h-15"></path>
+                                          </g>
+                                         </svg>
+                                    </a>
+                                    <a href="https://rancher.com/products/rke" class="menu-sub-block-item ">
+                                      <span>RKE</span>
+                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                        <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                          <path d="m19.5 12 5 5-5 5"></path>
+                                          <path d="m24.5 17h-15"></path>
+                                        </g>
+                                      </svg>
+                                    </a>
+                                    <a href="https://rancher.com/products/longhorn" class="menu-sub-block-item ">
+                                      <span>Longhorn</span>
+                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                        <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                          <path d="m19.5 12 5 5-5 5"></path>
+                                          <path d="m24.5 17h-15"></path>
+                                        </g>
+                                      </svg>
+                                    </a>
+                                    <a href="https://rancher.com/products/k3s" class="menu-sub-block-item ">
+                                      <span>K3s</span>
+                                        <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                          <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                            <path d="m19.5 12 5 5-5 5"></path>
+                                            <path d="m24.5 17h-15"></path>
+                                          </g>
+                                         </svg>
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </ul>
+                      </li>
+                      <li class="primary-menu-item menu-products">
+                        <a class="primary-menu" href="https://rancher.com/docs/">
+                            Docs
+                        </a>
+                      </li>
+                      <li class="primary-menu-item menu-products ">
+                        <a class="primary-menu" href="https://rancher.com/learn-the-basics">Learn</a>
+                        <ul class="primary-menus-sub">
+                          <div class="grid-container">
+                            <div class="row">
+                              <div class="col-12 right">
+                                <ul>
+                                  <li class="menus-container">
+                                    <a href="https://rancher.com/learn-the-basics" class="menu-sub-block-item ">
+                                      <span>Learn the Basics</span>
+                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                        <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                          <path d="m19.5 12 5 5-5 5"></path>
+                                          <path d="m24.5 17h-15"></path>
+                                        </g>
+                                      </svg>
+                                    </a>
+                                      <a href="https://rancher.com/grow-your-skills" class="menu-sub-block-item ">
+                                          <span>Grow Your Skills</span>
+                                          <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                              <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                  <path d="m19.5 12 5 5-5 5"></path>
+                                                  <path d="m24.5 17h-15"></path>
+                                              </g>
+                                          </svg>
+                                      </a>
+                                      <a href="https://training.suse.com/certification/sca-rancher-2-5/" class="menu-sub-block-item">
+                                          <span>Get Certified</span>
+                                          <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                              <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                  <path d="m19.5 12 5 5-5 5"></path>
+                                                  <path d="m24.5 17h-15"></path>
+                                              </g>
+                                          </svg>
+                                      </a>
+                                      <a href="https://rancher.com/docs/" class="menu-sub-block-item">
+                                          <span>Access Documentation</span>
+                                          <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                              <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                  <path d="m19.5 12 5 5-5 5"></path>
+                                                  <path d="m24.5 17h-15"></path>
+                                              </g>
+                                          </svg>
+                                      </a>
+                                      <a href="https://www.suse.com/c/rancherblog/" class="menu-sub-block-item">
+                                          <span>Read the Blogs</span>
+                                          <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                              <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                  <path d="m19.5 12 5 5-5 5"></path>
+                                                  <path d="m24.5 17h-15"></path>
+                                              </g>
+                                          </svg>
+                                      </a>
+                                      <a href="https://rancher.com/content-library" class="menu-sub-block-item ">
+                                          <span>Content Library</span>
+                                          <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                              <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                  <path d="m19.5 12 5 5-5 5"></path>
+                                                  <path d="m24.5 17h-15"></path>
+                                              </g>
+                                          </svg>
+                                      </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </ul>
+  
+                      </li>
+                      <li class="primary-menu-item menu-company ">
+                        <a class="primary-menu" href="https://rancher.com/community" rel="noopener">Community</a>
+                          <ul class="primary-menus-sub">
+                              <div class="grid-container">
+                                  <div class="row">
+                                      <div class="col-12 right">
+                                          <ul>
+                                              <li class="menus-container">
+                                                  <a href="https://rancher.com/about" class="menu-sub-block-item ">
+                                                    <span>About Us</span>
+                                                    <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                                      <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                        <path d="m19.5 12 5 5-5 5"></path>
+                                                        <path d="m24.5 17h-15"></path>
+                                                      </g>
+                                                    </svg>
+                                                  </a>
+                                                  <a href="https://rancher.com/community" class="menu-sub-block-item">
+                                                      <span>Join the Community</span>
+                                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                                          <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                              <path d="m19.5 12 5 5-5 5"></path>
+                                                              <path d="m24.5 17h-15"></path>
+                                                          </g>
+                                                      </svg>
+                                                  </a>
+                                                  <a href="https://www.suse.com/partners/" class="menu-sub-block-item">
+                                                      <span>Partners</span>
+                                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                                          <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                              <path d="m19.5 12 5 5-5 5"></path>
+                                                              <path d="m24.5 17h-15"></path>
+                                                          </g>
+                                                      </svg>
+                                                  </a>
+                                                  <a href="https://forums.rancher.com/" class="menu-sub-block-item">
+                                                      <span>Forums</span>
+                                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                                          <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                              <path d="m19.5 12 5 5-5 5"></path>
+                                                              <path d="m24.5 17h-15"></path>
+                                                          </g>
+                                                      </svg>
+                                                  </a>
+                                                  <a href="https://slack.rancher.io/" class="menu-sub-block-item">
+                                                      <span>Slack</span>
+                                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                                          <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                              <path d="m19.5 12 5 5-5 5"></path>
+                                                              <path d="m24.5 17h-15"></path>
+                                                          </g>
+                                                      </svg>
+                                                  </a>
+                                                  <a href="https://rancher.com/events" class="menu-sub-block-item ">
+                                                      <span>Events &amp; Webinars</span>
+                                                      <svg class="icon right" enable-background="new 0 0 34 34" viewBox="0 0 34 34" xmlns="http://www.w3.org/2000/svg">
+                                                          <g class="svg-linear" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10">
+                                                              <path d="m19.5 12 5 5-5 5"></path>
+                                                              <path d="m24.5 17h-15"></path>
+                                                          </g>
+                                                      </svg>
+                                                  </a>
+                                              </li>
+                                          </ul>
+                                      </div>
+                                  </div>
+                              </div>
+                          </ul>
+                      </li>
+                      <li class="primary-menu-item menu-get_started get-started">
+                        <a href="https://rancher.com/quick-start">Get started</a>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+              </div>
             </div>
-        </nav>
+          </nav>
     </header>
 
 <div class="modal-content" id="open-search">


### PR DESCRIPTION
This PR makes the header and tabs on rancher.com/docs look the same as the header and tabs on the rest of rancher.com.
<img width="1489" alt="Screen Shot 2022-09-08 at 2 26 26 PM" src="https://user-images.githubusercontent.com/20599230/189228931-f8d6d50f-a153-4f33-915c-be73c100eb50.png">

Source: I copy-pasted the nav code from rancher.com using the chrome developer tools.
